### PR TITLE
SSCS 4200 Dockerize Tribunals API

### DIFF
--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -229,7 +229,7 @@ services:
     image: hmcts/dm-store-db:latest
 
   sscs-tribunals-case-api:
-    image: hmcts:sscs-tribunals-case-api
+    image: hmcts/tribunals-case-api
     environment:
       EMAIL_SERVER_HOST: localhost
       EMAIL_SERVER_PORT: 1025

--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -237,7 +237,7 @@ services:
       CORE_CASE_DATA_API_URL: http://ccd-data-store-api:4452
       IDAM_URL: http://idam-api:8080
       IDAM_S2S_AUTH: http://service-auth-provider-api:8080
-      DOCUMENT_MANAGEMENT_URL: http://document-management-store:4603
+      DOCUMENT_MANAGEMENT_URL: http://document-management-store:8080
       IDAM_OAUTH2_REDIRECT_URL: https://localhost:9000/poc
     ports:
       - 8181:8080

--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -233,11 +233,11 @@ services:
     environment:
       EMAIL_SERVER_HOST: localhost
       EMAIL_SERVER_PORT: 1025
-      PDF_API_URL: http://localhost:5500
-      CORE_CASE_DATA_API_URL: http://localhost:4452
-      IDAM_URL: http://localhost:4501
-      IDAM_S2S_AUTH: http://localhost:4502
-      DOCUMENT_MANAGEMENT_URL: http://localhost:4603
+      PDF_API_URL: http://pdf-service-api:5500
+      CORE_CASE_DATA_API_URL: http://ccd-data-store-api:4452
+      IDAM_URL: http://idam-api:8080
+      IDAM_S2S_AUTH: http://service-auth-provider-api:8080
+      DOCUMENT_MANAGEMENT_URL: http://document-management-store:4603
       IDAM_OAUTH2_REDIRECT_URL: https://localhost:9000/poc
     ports:
       - 8181:8080

--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -231,7 +231,7 @@ services:
   sscs-tribunals-case-api:
     image: hmcts/tribunals-case-api
     environment:
-      EMAIL_SERVER_HOST: localhost
+      EMAIL_SERVER_HOST: smtp-server
       EMAIL_SERVER_PORT: 1025
       PDF_API_URL: http://pdf-service-api:5500
       CORE_CASE_DATA_API_URL: http://ccd-data-store-api:4452
@@ -240,7 +240,7 @@ services:
       DOCUMENT_MANAGEMENT_URL: http://document-management-store:8080
       IDAM_OAUTH2_REDIRECT_URL: https://localhost:9000/poc
     ports:
-      - 8181:8080
+      - 8080:8080
 
 volumes:
   ccd-docker-ccd-shared-database-data:

--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -228,5 +228,19 @@ services:
   document-management-store-database:
     image: hmcts/dm-store-db:latest
 
+  sscs-tribunals-case-api:
+    image: hmcts:sscs-tribunals-case-api
+    environment:
+      EMAIL_SERVER_HOST: localhost
+      EMAIL_SERVER_PORT: 1025
+      PDF_API_URL: http://localhost:5500
+      CORE_CASE_DATA_API_URL: http://localhost:4452
+      IDAM_URL: http://localhost:4501
+      IDAM_S2S_AUTH: http://localhost:4502
+      DOCUMENT_MANAGEMENT_URL: http://localhost:4603
+      IDAM_OAUTH2_REDIRECT_URL: https://localhost:9000/poc
+    ports:
+      - 8181:8080
+
 volumes:
   ccd-docker-ccd-shared-database-data:


### PR DESCRIPTION
This PR adds the Tribunals Case API to the Docker compose setup and makes it available on port 8080. This can be tested by bringing up the containers:

./compose-frontend.sh up -d

Then, wait about five minutes and run

curl http://localhost:8080/health

And check that the TCAPI is healthy.

A deeper test can be carried out by submitting an appeal locally via the SYA front end.