### PR TITLE
Set the CCD_DOCUMENT_URL_PATTERN variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,7 +52,7 @@ export APPINSIGHTS_INSTRUMENTATIONKEY=SomeRandomStringForLocalDocker
 
 export ES_ENABLED_DOCKER=false
 
-export CCD_DOCUMENT_URL_PATTERN="http://dm-store:5005/documents/[A-Za-z0-9-]+(?:/binary)"
+export CCD_DOCUMENT_URL_PATTERN="http://dm-store.*"
 
 unset IDAM_STUB_LOCALHOST
 unset IDAM_STUB_SERVICE_NAME

--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,8 @@ export APPINSIGHTS_INSTRUMENTATIONKEY=SomeRandomStringForLocalDocker
 
 export ES_ENABLED_DOCKER=false
 
+export CCD_DOCUMENT_URL_PATTERN="http://dm-store:5005/documents/[A-Za-z0-9-]+(?:/binary)"
+
 unset IDAM_STUB_LOCALHOST
 unset IDAM_STUB_SERVICE_NAME
 #For Idam stubs


### PR DESCRIPTION
Set the CCD_DOCUMENT_URL_PATTERN variable

Need to restart ccd-data-store-api
i.e.

```bash
docker stop compose_ccd-data-store-api_1 
docker rm compose_ccd-data-store-api_1 
# ./ccd compose pull  ccd-case-document-am-api (Optional if you want to pull the latest image)
./ccd compose up -d ccd-data-store-api 
```