### PR TITLE
Add CCD user

### DIFF
--- a/bin/create-simulator-users.sh
+++ b/bin/create-simulator-users.sh
@@ -11,3 +11,5 @@ source .env
 ./bin/simulator-create-caseworker.sh caseworker,caseworker-sscs,caseworker-sscs-judge judge@example.com Pa55word11 Judge user
 
 ./bin/simulator-create-caseworker.sh citizen sscs-citizen2@hmcts.net
+
+./bin/simulator-create-caseworker.sh manage-user data.store.idam.system.user@gmail.com


### PR DESCRIPTION
Add CCD user
This user is required by the latest version of ccd data store
There is a call to idam to authenticate this user when creating a new draft appeal via SYA