### PR TITLE
change the docmosis ip address

### DIFF
--- a/compose/dm-store.yml
+++ b/compose/dm-store.yml
@@ -39,7 +39,7 @@ services:
     ports:
       - 4631:8080
     extra_hosts:
-      - "docmosis.aat.platform.hmcts.net:10.10.24.121"
+      - "docmosis.aat.platform.hmcts.net:10.10.161.121"
     networks:
       - ccd-network
 


### PR DESCRIPTION
change the docmosis ip address

Not sure if we need the extra_hosts: bit for docmosis, the ip address could change in the future, just like it has now. Maybe, something to be weary off the next time docassembly doesn't work.